### PR TITLE
new PRISM API

### DIFF
--- a/R/calc_gdd_doy.R
+++ b/R/calc_gdd_doy.R
@@ -80,30 +80,32 @@ calc_gdd_be_doy <- function(tmin_dir, tmax_dir, roi, gdd_threshold, gdd_base = 3
 }
 
 
-
-read_prism <- function(rast_dir) {
+# NOTE: If using get_prism2(), change default ext to ".tif" or set it to ".tif"
+# everywhere read_prism is used.
+read_prism <- function(rast_dir, ext = c(".bil", ".tif")) {
+  ext <- match.arg(ext)
   files <- fs::dir_ls(rast_dir, glob = "*.zip")
-  
+
   #convert filenames to DOY to use for layer names
   doys <- files |>
     fs::path_file() |>
     stringr::str_extract("\\d{8}") |>
-    lubridate::ymd() |> 
+    lubridate::ymd() |>
     lubridate::yday()
-  
+
   #construct paths with /vsizip/ to read inside .zip files
-  bils <- 
-    files |> 
+  rasts <-
+    files |>
     fs::path_file() |>
-    fs::path_ext_set(".bil")
-  rast_paths <- paste0("/vsizip/", fs::path(files, bils))
-  
+    fs::path_ext_set(ext)
+  rast_paths <- paste0("/vsizip/", fs::path(files, rasts))
+
   #read in multi-layer rasters
   prism <- terra::rast(rast_paths)
   names(prism) <- doys
-  
+
   #convert to ºF
-  prism <- prism * (9/5) + 32
+  prism <- prism * (9 / 5) + 32
   terra::units(prism) <- "ºF"
   #sort layers by DOY
   prism <- terra::subset(prism, as.character(min(doys):max(doys)))

--- a/R/calc_gdd_doy.R
+++ b/R/calc_gdd_doy.R
@@ -82,7 +82,7 @@ calc_gdd_be_doy <- function(tmin_dir, tmax_dir, roi, gdd_threshold, gdd_base = 3
 
 # NOTE: If using get_prism2(), change default ext to ".tif" or set it to ".tif"
 # everywhere read_prism is used.
-read_prism <- function(rast_dir, ext = c(".bil", ".tif")) {
+read_prism <- function(rast_dir) {
   ext <- match.arg(ext)
   files <- fs::dir_ls(rast_dir, glob = "*.zip")
 
@@ -94,11 +94,11 @@ read_prism <- function(rast_dir, ext = c(".bil", ".tif")) {
     lubridate::yday()
 
   #construct paths with /vsizip/ to read inside .zip files
-  rasts <-
+  bils <-
     files |>
     fs::path_file() |>
-    fs::path_ext_set(ext)
-  rast_paths <- paste0("/vsizip/", fs::path(files, rasts))
+    fs::path_ext_set(".bil")
+  rast_paths <- paste0("/vsizip/", fs::path(files, bils))
 
   #read in multi-layer rasters
   prism <- terra::rast(rast_paths)

--- a/R/calc_gdd_doy.R
+++ b/R/calc_gdd_doy.R
@@ -80,10 +80,7 @@ calc_gdd_be_doy <- function(tmin_dir, tmax_dir, roi, gdd_threshold, gdd_base = 3
 }
 
 
-# NOTE: If using get_prism2(), change default ext to ".tif" or set it to ".tif"
-# everywhere read_prism is used.
 read_prism <- function(rast_dir) {
-  ext <- match.arg(ext)
   files <- fs::dir_ls(rast_dir, glob = "*.zip")
 
   #convert filenames to DOY to use for layer names

--- a/R/get_prism.R
+++ b/R/get_prism.R
@@ -1,11 +1,16 @@
-#' Download data from PRISM
+#' Download data from PRISM (defunct API)
 #'
-#' Downloads an entire year of data from PRISM using `get_prism_dailys()`
-#' and returns the download path so it works with `format = 'file'` in `targets`
+#' Downloads an entire year of daily data from PRISM and returns the download
+#' path so it works with `format = 'file'` in `targets`.
+#' 
+#' NOTE: this works with v1 of the PRISM API which has been disabled as of Sep
+#' 30, 2025.  Use [get_prism2()] for the newer API.
+#' https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf
 #'
 #' @param year year of data to be downloaded
 #' @param variable variable to get
-#' @param prism_dir base directory for PRISM data.  Subfolders will be created for the variable and year
+#' @param prism_dir base directory for PRISM data.  Subfolders will be created
+#'   for the variable and year
 #'
 #' @return path to folder for that year of data
 get_prism <- function(year, variable = c("tmin", "tmax", "tmean"), prism_dir = "data/prism") {

--- a/R/get_prism2.R
+++ b/R/get_prism2.R
@@ -1,0 +1,98 @@
+#' Download data from PRISM
+#'
+#' Downloads an entire year of daily data from PRISM and returns the download
+#' path so it works with `format = 'file'` in `targets`.
+#'
+#' NOTE: this works with the latest version of the PRISM API as of Sep. 30,
+#' 2025. https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf
+#'
+#' @param year year of data to be downloaded
+#' @param variable variable to get
+#' @param prism_dir base directory for PRISM data.  Subfolders will be created
+#'   for the variable and year
+#'
+#' @return path to folder for that year of data
+get_prism2 <- function(
+  year,
+  variable = c("tmin", "tmax", "tmean"),
+  prism_dir = "data/prism"
+) {
+  variable <- match.arg(variable)
+
+  base_req <-
+    httr2::request("https://services.nacse.org/prism/data/get") |>
+    httr2::req_user_agent(
+      "University of Arizona CCT Data Science (https://datascience.cct.arizona.edu/)"
+    ) |>
+    httr2::req_retry(max_tries = 10) |>
+    httr2::req_url_path_append("us", "4km") |>
+    httr2::req_throttle(capacity = 1, fill_time_s = 3)
+
+  cli::cli_alert("Downloading PRISM {variable} data for {year}")
+
+  #check if path exists and create if not
+  year_dir <- fs::dir_create(fs::path(prism_dir, variable, year))
+
+  #make sequence of dates
+  date_start <- lubridate::make_date(year = year)
+  date_end <- lubridate::make_date(year = year, month = 12, day = 31)
+  dates <- seq(date_start, date_end, "day")
+
+  req <- base_req |> httr2::req_url_path_append(variable)
+
+  reqs <- purrr::map(dates, \(x) {
+    req |> httr2::req_url_path_append(format(x, "%Y%m%d"))
+  })
+
+  # retrieve filenames
+  head_reqs <- purrr::map(reqs, \(x) httr2::req_method(x, "HEAD"))
+  head_resps <- httr2::req_perform_sequential(
+    head_reqs,
+    progress = "Retrieving filenames"
+  )
+  filenames <- head_resps |>
+    purrr::map_chr(\(x) {
+      x$headers$`Content-Disposition` |>
+        stringr::str_remove("filename=") |>
+        stringr::str_remove_all('\\"') |>
+        fs::path()
+    })
+
+  filepaths <- fs::path(year_dir, filenames)
+  # Figure out which ones need to be downloaded
+  files_exist <- fs::file_exists(filepaths)
+
+  reqs_to_perform <- reqs[!files_exist]
+  files_to_dl <- filepaths[!files_exist]
+
+  # TODO: there is a release date web service that could be used to determine if
+  # any files need updating.  Files released 6 months ago are considered
+  # "stable".
+  # https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf
+  # E.g. https://services.nacse.org/prism/data/get/releaseDate/us/4km/{variable}/{format(date_start, "%Y%m%d")}/{format(date_end, "%Y%m%d")}?json=true
+
+  cli::cli_alert_info("{length(reqs_to_perform)} files to download")
+
+  if (length(reqs_to_perform) > 0) {
+    resp <-
+      httr2::req_perform_sequential(
+        reqs_to_perform,
+        paths = files_to_dl,
+        progress = "Downloading"
+      )
+    #check that they are actually zip files and if not change extension to .txt
+
+    purrr::walk(files_to_dl, \(x) {
+      is_zip <- check_zip_file(x)
+      if (!isTRUE(is_zip)) {
+        warning(is_zip)
+        file.rename(x, fs::path_ext_set(x, "txt"))
+      }
+    })
+  } else {
+    cli::cli_alert_info("Skipping downloading.")
+  }
+
+  #return the path to the folder so targets tracks the whole dang thing
+  invisible(year_dir)
+}

--- a/README.Qmd
+++ b/README.Qmd
@@ -63,8 +63,6 @@ cat(
 
 In the process of writing this manuscript, the PRISM API changed ([new API documentation](https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf)).
 The current `targets` pipeline won't work with the new API, but we've provided a function, `get_prism2()` that should be a drop-in replacement wherever `get_prism()` is used.
-Anywhere `read_prism()` is used, the `ext` argument will  need to be set to `".tif"` as well.
-E.g. in `calc_gdd_doy.R`, `prism_tmin <- read_prism(tmin_dir)` would need to be changed to `prism_tmin <- read_prism(tmin_dir, ext = ".tif")`.
 
 ------------------------------------------------------------------------
 

--- a/README.Qmd
+++ b/README.Qmd
@@ -59,6 +59,13 @@ cat(
 #this should display correctly on GitHub, or code can be pasted into https://mermaid.live
 ```
 
+### PRISM API
+
+In the process of writing this manuscript, the PRISM API changed ([new API documentation](https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf)).
+The current `targets` pipeline won't work with the new API, but we've provided a function, `get_prism2()` that should be a drop-in replacement wherever `get_prism()` is used.
+Anywhere `read_prism()` is used, the `ext` argument will  need to be set to `".tif"` as well.
+E.g. in `calc_gdd_doy.R`, `prism_tmin <- read_prism(tmin_dir)` would need to be changed to `prism_tmin <- read_prism(tmin_dir, ext = ".tif")`.
+
 ------------------------------------------------------------------------
 
 Developed in collaboration with the University of Arizona [CCT Data Science](https://datascience.cct.arizona.edu/) group.

--- a/README.md
+++ b/README.md
@@ -59,135 +59,133 @@ graph LR
   style Legend fill:#FFFFFF00,stroke:#000000;
   style Graph fill:#FFFFFF00,stroke:#000000;
   subgraph Legend
-    x2db1ec7a48f65a9b(["Outdated"]):::outdated
-    xb6630624a7b3aa0f(["Dispatched"]):::dispatched
     xf1522833a4d242c5(["Up to date"]):::uptodate
+    xb6630624a7b3aa0f(["Dispatched"]):::dispatched
     xd03d7c7dd2ddda2b(["Regular target"]):::none
     x6f7e04ea3427f824["Dynamic branches"]:::none
   end
   subgraph Graph
     direction LR
-    xeb357bf500cb426f(["slope_differences"]):::outdated --> x1a57d81f9d478e5e(["by_state_slope_diff_summary"]):::outdated
-    x4293cc4b2ce98353(["roi_sf"]):::uptodate --> x1a57d81f9d478e5e(["by_state_slope_diff_summary"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    x4293cc4b2ce98353(["roi_sf"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::outdated
-    x3290bd5727894db5(["stack_1250"]):::outdated --> xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated
-    x8aa20a6b22429bc6(["stack_1950"]):::outdated --> xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated
-    x9bfde4bdb66389ab(["stack_2500"]):::outdated --> xd187396e35b9df6a(["doy_summary_2500"]):::outdated
-    xc842f879425cacb9(["stack_350"]):::outdated --> xe3bc9075e32f80ca(["doy_summary_350"]):::outdated
-    xff5a5197cb4eb936(["stack_50"]):::outdated --> xdc621d8734e6de6d(["doy_summary_50"]):::outdated
-    x98420a84329bc56b(["stack_650"]):::outdated --> xd36e999b706381d6(["doy_summary_650"]):::outdated
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::outdated
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::outdated
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::outdated
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::dispatched
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::dispatched
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::dispatched
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::outdated
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::outdated
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::outdated
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::outdated
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::outdated
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
-    x8aa20a6b22429bc6(["stack_1950"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    x98420a84329bc56b(["stack_650"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    xc842f879425cacb9(["stack_350"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    x9bfde4bdb66389ab(["stack_2500"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    xff5a5197cb4eb936(["stack_50"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    x3290bd5727894db5(["stack_1250"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
-    x41b128208ccec715(["poi_pred_doy"]):::outdated --> xbd115849bddb4a76(["poi_shifts_plot"]):::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> xbd115849bddb4a76(["poi_shifts_plot"]):::outdated
-    xc303273133d8a2cf(["poi_stats_350"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
-    x87ab2591407fd72c(["poi_stats_650"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
-    xbdede1d17e2cddbb(["poi_stats_2500"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
-    x4a0f84ca502caa8d(["poi_stats_1950"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
-    x6fbb12a3bc31060f(["poi_stats_1250"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
-    x585c954b4e620bc6(["poi_stats_50"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> x6fbb12a3bc31060f(["poi_stats_1250"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x6fbb12a3bc31060f(["poi_stats_1250"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x4a0f84ca502caa8d(["poi_stats_1950"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> x4a0f84ca502caa8d(["poi_stats_1950"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> xbdede1d17e2cddbb(["poi_stats_2500"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> xbdede1d17e2cddbb(["poi_stats_2500"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> xc303273133d8a2cf(["poi_stats_350"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> xc303273133d8a2cf(["poi_stats_350"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x585c954b4e620bc6(["poi_stats_50"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> x585c954b4e620bc6(["poi_stats_50"]):::outdated
-    x556077819df2ba0d(["poi"]):::uptodate --> x87ab2591407fd72c(["poi_stats_650"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x87ab2591407fd72c(["poi_stats_650"]):::outdated
+    xeb357bf500cb426f(["slope_differences"]):::uptodate --> x1a57d81f9d478e5e(["by_state_slope_diff_summary"]):::uptodate
+    x4293cc4b2ce98353(["roi_sf"]):::uptodate --> x1a57d81f9d478e5e(["by_state_slope_diff_summary"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    x4293cc4b2ce98353(["roi_sf"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
+    x3290bd5727894db5(["stack_1250"]):::uptodate --> xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate
+    x8aa20a6b22429bc6(["stack_1950"]):::uptodate --> xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate
+    x9bfde4bdb66389ab(["stack_2500"]):::uptodate --> xd187396e35b9df6a(["doy_summary_2500"]):::uptodate
+    xc842f879425cacb9(["stack_350"]):::uptodate --> xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate
+    xff5a5197cb4eb936(["stack_50"]):::uptodate --> xdc621d8734e6de6d(["doy_summary_50"]):::uptodate
+    x98420a84329bc56b(["stack_650"]):::uptodate --> xd36e999b706381d6(["doy_summary_650"]):::uptodate
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::uptodate
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::uptodate
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::uptodate
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::uptodate
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::uptodate
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::uptodate
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::uptodate
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::uptodate
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::uptodate
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::uptodate
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
+    x8aa20a6b22429bc6(["stack_1950"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    x98420a84329bc56b(["stack_650"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    xc842f879425cacb9(["stack_350"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    x9bfde4bdb66389ab(["stack_2500"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    xff5a5197cb4eb936(["stack_50"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    x3290bd5727894db5(["stack_1250"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
+    x41b128208ccec715(["poi_pred_doy"]):::uptodate --> xbd115849bddb4a76(["poi_shifts_plot"]):::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> xbd115849bddb4a76(["poi_shifts_plot"]):::uptodate
+    xc303273133d8a2cf(["poi_stats_350"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
+    x87ab2591407fd72c(["poi_stats_650"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
+    xbdede1d17e2cddbb(["poi_stats_2500"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
+    x4a0f84ca502caa8d(["poi_stats_1950"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
+    x6fbb12a3bc31060f(["poi_stats_1250"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
+    x585c954b4e620bc6(["poi_stats_50"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> x6fbb12a3bc31060f(["poi_stats_1250"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x6fbb12a3bc31060f(["poi_stats_1250"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x4a0f84ca502caa8d(["poi_stats_1950"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> x4a0f84ca502caa8d(["poi_stats_1950"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> xbdede1d17e2cddbb(["poi_stats_2500"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> xbdede1d17e2cddbb(["poi_stats_2500"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> xc303273133d8a2cf(["poi_stats_350"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> xc303273133d8a2cf(["poi_stats_350"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x585c954b4e620bc6(["poi_stats_50"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> x585c954b4e620bc6(["poi_stats_50"]):::uptodate
+    x556077819df2ba0d(["poi"]):::uptodate --> x87ab2591407fd72c(["poi_stats_650"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x87ab2591407fd72c(["poi_stats_650"]):::uptodate
     xf9ac23fbc741da6f(["years"]):::uptodate --> xb76c0bbea0c751b0["prism_tmax"]:::uptodate
     xf9ac23fbc741da6f(["years"]):::uptodate --> xcaf68fce9acaa5b6["prism_tmin"]:::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
-    xeb357bf500cb426f(["slope_differences"]):::outdated --> x37fe5b550c0a1008(["slope_differences_plot"]):::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x37fe5b550c0a1008(["slope_differences_plot"]):::outdated
-    xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated --> x3290bd5727894db5(["stack_1250"]):::outdated
-    x2fee061101c79ea2["gdd_doy_1950"]:::outdated --> x8aa20a6b22429bc6(["stack_1950"]):::outdated
-    x28c62ae9542e7849["gdd_doy_2500"]:::dispatched --> x9bfde4bdb66389ab(["stack_2500"]):::outdated
-    x2d1ead242fc1f865["gdd_doy_350"]:::outdated --> xc842f879425cacb9(["stack_350"]):::outdated
-    x786a1a0a06ddc553["gdd_doy_50"]:::outdated --> xff5a5197cb4eb936(["stack_50"]):::outdated
-    x6672cfab7f0558ba["gdd_doy_650"]:::outdated --> x98420a84329bc56b(["stack_650"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
-    x21512ad81bd47b85(["summary_summary_1250"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
-    x22d1d76737e8c96c(["summary_summary_1950"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
-    x98d5cb9b25df8fa2(["summary_summary_2500"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
-    x482d008952893a57(["summary_summary_350"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
-    xd673ca3454c59fd6(["summary_summary_50"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
-    x8817687a9adb871f(["summary_summary_650"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x21512ad81bd47b85(["summary_summary_1250"]):::outdated
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x22d1d76737e8c96c(["summary_summary_1950"]):::outdated
-    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x98d5cb9b25df8fa2(["summary_summary_2500"]):::outdated
-    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x482d008952893a57(["summary_summary_350"]):::outdated
-    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> xd673ca3454c59fd6(["summary_summary_50"]):::outdated
-    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x8817687a9adb871f(["summary_summary_650"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
+    xeb357bf500cb426f(["slope_differences"]):::uptodate --> x37fe5b550c0a1008(["slope_differences_plot"]):::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x37fe5b550c0a1008(["slope_differences_plot"]):::uptodate
+    xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate --> x3290bd5727894db5(["stack_1250"]):::uptodate
+    x2fee061101c79ea2["gdd_doy_1950"]:::uptodate --> x8aa20a6b22429bc6(["stack_1950"]):::uptodate
+    x28c62ae9542e7849["gdd_doy_2500"]:::uptodate --> x9bfde4bdb66389ab(["stack_2500"]):::uptodate
+    x2d1ead242fc1f865["gdd_doy_350"]:::uptodate --> xc842f879425cacb9(["stack_350"]):::uptodate
+    x786a1a0a06ddc553["gdd_doy_50"]:::uptodate --> xff5a5197cb4eb936(["stack_50"]):::uptodate
+    x6672cfab7f0558ba["gdd_doy_650"]:::uptodate --> x98420a84329bc56b(["stack_650"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
+    x21512ad81bd47b85(["summary_summary_1250"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
+    x22d1d76737e8c96c(["summary_summary_1950"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
+    x98d5cb9b25df8fa2(["summary_summary_2500"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
+    x482d008952893a57(["summary_summary_350"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
+    xd673ca3454c59fd6(["summary_summary_50"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
+    x8817687a9adb871f(["summary_summary_650"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x21512ad81bd47b85(["summary_summary_1250"]):::uptodate
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x22d1d76737e8c96c(["summary_summary_1950"]):::uptodate
+    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x98d5cb9b25df8fa2(["summary_summary_2500"]):::uptodate
+    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x482d008952893a57(["summary_summary_350"]):::uptodate
+    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> xd673ca3454c59fd6(["summary_summary_50"]):::uptodate
+    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x8817687a9adb871f(["summary_summary_650"]):::uptodate
     xc11069275cfeb620(["readme"]):::dispatched
   end
-  classDef outdated stroke:#000000,color:#000000,fill:#78B7C5;
-  classDef dispatched stroke:#000000,color:#000000,fill:#DC863B;
   classDef uptodate stroke:#000000,color:#ffffff,fill:#354823;
+  classDef dispatched stroke:#000000,color:#000000,fill:#DC863B;
   classDef none stroke:#000000,color:#000000,fill:#94a4ac;
 ```
 
@@ -198,10 +196,7 @@ API
 documentation](https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf)).
 The current `targets` pipeline won’t work with the new API, but we’ve
 provided a function, `get_prism2()` that should be a drop-in replacement
-wherever `get_prism()` is used. Anywhere `read_prism()` is used, the
-`ext` argument will need to be set to `".tif"` as well. E.g. in
-`calc_gdd_doy.R`, `prism_tmin <- read_prism(tmin_dir)` would need to be
-changed to `prism_tmin <- read_prism(tmin_dir, ext = ".tif")`.
+wherever `get_prism()` is used.
 
 ------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -59,126 +59,149 @@ graph LR
   style Legend fill:#FFFFFF00,stroke:#000000;
   style Graph fill:#FFFFFF00,stroke:#000000;
   subgraph Legend
-    xf1522833a4d242c5(["Up to date"]):::uptodate
+    x2db1ec7a48f65a9b(["Outdated"]):::outdated
     xb6630624a7b3aa0f(["Dispatched"]):::dispatched
+    xf1522833a4d242c5(["Up to date"]):::uptodate
     xd03d7c7dd2ddda2b(["Regular target"]):::none
     x6f7e04ea3427f824["Dynamic branches"]:::none
   end
   subgraph Graph
     direction LR
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::uptodate
-    x3290bd5727894db5(["stack_1250"]):::uptodate --> xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate
-    x8aa20a6b22429bc6(["stack_1950"]):::uptodate --> xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate
-    x9bfde4bdb66389ab(["stack_2500"]):::uptodate --> xd187396e35b9df6a(["doy_summary_2500"]):::uptodate
-    xc842f879425cacb9(["stack_350"]):::uptodate --> xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate
-    xff5a5197cb4eb936(["stack_50"]):::uptodate --> xdc621d8734e6de6d(["doy_summary_50"]):::uptodate
-    x98420a84329bc56b(["stack_650"]):::uptodate --> xd36e999b706381d6(["doy_summary_650"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::uptodate
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::uptodate
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::uptodate
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::uptodate
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::uptodate
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::uptodate
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::uptodate
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::uptodate
-    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::uptodate
-    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::uptodate
-    xff5a5197cb4eb936(["stack_50"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    xc842f879425cacb9(["stack_350"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    x98420a84329bc56b(["stack_650"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    x8aa20a6b22429bc6(["stack_1950"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    x3290bd5727894db5(["stack_1250"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    x9bfde4bdb66389ab(["stack_2500"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::uptodate
-    x41b128208ccec715(["poi_pred_doy"]):::uptodate --> xbd115849bddb4a76(["poi_shifts_plot"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> xbd115849bddb4a76(["poi_shifts_plot"]):::uptodate
-    x4a0f84ca502caa8d(["poi_stats_1950"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
-    xbdede1d17e2cddbb(["poi_stats_2500"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
-    x585c954b4e620bc6(["poi_stats_50"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
-    x6fbb12a3bc31060f(["poi_stats_1250"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
-    x87ab2591407fd72c(["poi_stats_650"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
-    xc303273133d8a2cf(["poi_stats_350"]):::uptodate --> x7a722b64ce2ed1a1(["poi_stats"]):::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x6fbb12a3bc31060f(["poi_stats_1250"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> x6fbb12a3bc31060f(["poi_stats_1250"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> x4a0f84ca502caa8d(["poi_stats_1950"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x4a0f84ca502caa8d(["poi_stats_1950"]):::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> xbdede1d17e2cddbb(["poi_stats_2500"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> xbdede1d17e2cddbb(["poi_stats_2500"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> xc303273133d8a2cf(["poi_stats_350"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> xc303273133d8a2cf(["poi_stats_350"]):::uptodate
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x585c954b4e620bc6(["poi_stats_50"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> x585c954b4e620bc6(["poi_stats_50"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x87ab2591407fd72c(["poi_stats_650"]):::uptodate
-    x556077819df2ba0d(["poi"]):::uptodate --> x87ab2591407fd72c(["poi_stats_650"]):::uptodate
+    xeb357bf500cb426f(["slope_differences"]):::outdated --> x1a57d81f9d478e5e(["by_state_slope_diff_summary"]):::outdated
+    x4293cc4b2ce98353(["roi_sf"]):::uptodate --> x1a57d81f9d478e5e(["by_state_slope_diff_summary"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    x4293cc4b2ce98353(["roi_sf"]):::uptodate --> x224b4ae6d4917e15(["by_state_summary"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x11c2bf776c83b19c(["count_plot"]):::outdated
+    x3290bd5727894db5(["stack_1250"]):::outdated --> xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated
+    x8aa20a6b22429bc6(["stack_1950"]):::outdated --> xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated
+    x9bfde4bdb66389ab(["stack_2500"]):::outdated --> xd187396e35b9df6a(["doy_summary_2500"]):::outdated
+    xc842f879425cacb9(["stack_350"]):::outdated --> xe3bc9075e32f80ca(["doy_summary_350"]):::outdated
+    xff5a5197cb4eb936(["stack_50"]):::outdated --> xdc621d8734e6de6d(["doy_summary_50"]):::outdated
+    x98420a84329bc56b(["stack_650"]):::outdated --> xd36e999b706381d6(["doy_summary_650"]):::outdated
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::outdated
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::outdated
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2fee061101c79ea2["gdd_doy_1950"]:::outdated
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::dispatched
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::dispatched
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x28c62ae9542e7849["gdd_doy_2500"]:::dispatched
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::outdated
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x2d1ead242fc1f865["gdd_doy_350"]:::outdated
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::outdated
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x786a1a0a06ddc553["gdd_doy_50"]:::outdated
+    xb76c0bbea0c751b0["prism_tmax"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::outdated
+    xcaf68fce9acaa5b6["prism_tmin"]:::uptodate --> x6672cfab7f0558ba["gdd_doy_650"]:::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x9a95e37bbec60034(["linear_slopes_plot"]):::outdated
+    x8aa20a6b22429bc6(["stack_1950"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    x98420a84329bc56b(["stack_650"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    xc842f879425cacb9(["stack_350"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    x9bfde4bdb66389ab(["stack_2500"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    xff5a5197cb4eb936(["stack_50"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    x3290bd5727894db5(["stack_1250"]):::outdated --> x41b128208ccec715(["poi_pred_doy"]):::outdated
+    x41b128208ccec715(["poi_pred_doy"]):::outdated --> xbd115849bddb4a76(["poi_shifts_plot"]):::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> xbd115849bddb4a76(["poi_shifts_plot"]):::outdated
+    xc303273133d8a2cf(["poi_stats_350"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
+    x87ab2591407fd72c(["poi_stats_650"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
+    xbdede1d17e2cddbb(["poi_stats_2500"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
+    x4a0f84ca502caa8d(["poi_stats_1950"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
+    x6fbb12a3bc31060f(["poi_stats_1250"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
+    x585c954b4e620bc6(["poi_stats_50"]):::outdated --> x7a722b64ce2ed1a1(["poi_stats"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> x6fbb12a3bc31060f(["poi_stats_1250"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x6fbb12a3bc31060f(["poi_stats_1250"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x4a0f84ca502caa8d(["poi_stats_1950"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> x4a0f84ca502caa8d(["poi_stats_1950"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> xbdede1d17e2cddbb(["poi_stats_2500"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> xbdede1d17e2cddbb(["poi_stats_2500"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> xc303273133d8a2cf(["poi_stats_350"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> xc303273133d8a2cf(["poi_stats_350"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x585c954b4e620bc6(["poi_stats_50"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> x585c954b4e620bc6(["poi_stats_50"]):::outdated
+    x556077819df2ba0d(["poi"]):::uptodate --> x87ab2591407fd72c(["poi_stats_650"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x87ab2591407fd72c(["poi_stats_650"]):::outdated
     xf9ac23fbc741da6f(["years"]):::uptodate --> xb76c0bbea0c751b0["prism_tmax"]:::uptodate
     xf9ac23fbc741da6f(["years"]):::uptodate --> xcaf68fce9acaa5b6["prism_tmin"]:::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> xeb357bf500cb426f(["slope_differences"]):::uptodate
-    xeb357bf500cb426f(["slope_differences"]):::uptodate --> x37fe5b550c0a1008(["slope_differences_plot"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x37fe5b550c0a1008(["slope_differences_plot"]):::uptodate
-    xc8e128aab3cd4a9e["gdd_doy_1250"]:::uptodate --> x3290bd5727894db5(["stack_1250"]):::uptodate
-    x2fee061101c79ea2["gdd_doy_1950"]:::uptodate --> x8aa20a6b22429bc6(["stack_1950"]):::uptodate
-    x28c62ae9542e7849["gdd_doy_2500"]:::uptodate --> x9bfde4bdb66389ab(["stack_2500"]):::uptodate
-    x2d1ead242fc1f865["gdd_doy_350"]:::uptodate --> xc842f879425cacb9(["stack_350"]):::uptodate
-    x786a1a0a06ddc553["gdd_doy_50"]:::uptodate --> xff5a5197cb4eb936(["stack_50"]):::uptodate
-    x6672cfab7f0558ba["gdd_doy_650"]:::uptodate --> x98420a84329bc56b(["stack_650"]):::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    x73ccc223e5bb7e64(["roi"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::uptodate
-    x21512ad81bd47b85(["summary_summary_1250"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
-    x22d1d76737e8c96c(["summary_summary_1950"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
-    x98d5cb9b25df8fa2(["summary_summary_2500"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
-    x482d008952893a57(["summary_summary_350"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
-    xd673ca3454c59fd6(["summary_summary_50"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
-    x8817687a9adb871f(["summary_summary_650"]):::uptodate --> xeb07a0ecc48d018b(["summary_summary"]):::uptodate
-    xe7a2595a28ea2e04(["doy_summary_1250"]):::uptodate --> x21512ad81bd47b85(["summary_summary_1250"]):::uptodate
-    xc884cdd4fb17c69f(["doy_summary_1950"]):::uptodate --> x22d1d76737e8c96c(["summary_summary_1950"]):::uptodate
-    xd187396e35b9df6a(["doy_summary_2500"]):::uptodate --> x98d5cb9b25df8fa2(["summary_summary_2500"]):::uptodate
-    xe3bc9075e32f80ca(["doy_summary_350"]):::uptodate --> x482d008952893a57(["summary_summary_350"]):::uptodate
-    xdc621d8734e6de6d(["doy_summary_50"]):::uptodate --> xd673ca3454c59fd6(["summary_summary_50"]):::uptodate
-    xd36e999b706381d6(["doy_summary_650"]):::uptodate --> x8817687a9adb871f(["summary_summary_650"]):::uptodate
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x1a7be1bbbb0646ca(["sd_plot"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> xeb357bf500cb426f(["slope_differences"]):::outdated
+    xeb357bf500cb426f(["slope_differences"]):::outdated --> x37fe5b550c0a1008(["slope_differences_plot"]):::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x37fe5b550c0a1008(["slope_differences_plot"]):::outdated
+    xc8e128aab3cd4a9e["gdd_doy_1250"]:::outdated --> x3290bd5727894db5(["stack_1250"]):::outdated
+    x2fee061101c79ea2["gdd_doy_1950"]:::outdated --> x8aa20a6b22429bc6(["stack_1950"]):::outdated
+    x28c62ae9542e7849["gdd_doy_2500"]:::dispatched --> x9bfde4bdb66389ab(["stack_2500"]):::outdated
+    x2d1ead242fc1f865["gdd_doy_350"]:::outdated --> xc842f879425cacb9(["stack_350"]):::outdated
+    x786a1a0a06ddc553["gdd_doy_50"]:::outdated --> xff5a5197cb4eb936(["stack_50"]):::outdated
+    x6672cfab7f0558ba["gdd_doy_650"]:::outdated --> x98420a84329bc56b(["stack_650"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    x73ccc223e5bb7e64(["roi"]):::uptodate --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x000fd996de9c9b5d(["summary_plot"]):::outdated
+    x21512ad81bd47b85(["summary_summary_1250"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
+    x22d1d76737e8c96c(["summary_summary_1950"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
+    x98d5cb9b25df8fa2(["summary_summary_2500"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
+    x482d008952893a57(["summary_summary_350"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
+    xd673ca3454c59fd6(["summary_summary_50"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
+    x8817687a9adb871f(["summary_summary_650"]):::outdated --> xeb07a0ecc48d018b(["summary_summary"]):::outdated
+    xe7a2595a28ea2e04(["doy_summary_1250"]):::outdated --> x21512ad81bd47b85(["summary_summary_1250"]):::outdated
+    xc884cdd4fb17c69f(["doy_summary_1950"]):::outdated --> x22d1d76737e8c96c(["summary_summary_1950"]):::outdated
+    xd187396e35b9df6a(["doy_summary_2500"]):::outdated --> x98d5cb9b25df8fa2(["summary_summary_2500"]):::outdated
+    xe3bc9075e32f80ca(["doy_summary_350"]):::outdated --> x482d008952893a57(["summary_summary_350"]):::outdated
+    xdc621d8734e6de6d(["doy_summary_50"]):::outdated --> xd673ca3454c59fd6(["summary_summary_50"]):::outdated
+    xd36e999b706381d6(["doy_summary_650"]):::outdated --> x8817687a9adb871f(["summary_summary_650"]):::outdated
     xc11069275cfeb620(["readme"]):::dispatched
   end
-  classDef uptodate stroke:#000000,color:#ffffff,fill:#354823;
+  classDef outdated stroke:#000000,color:#000000,fill:#78B7C5;
   classDef dispatched stroke:#000000,color:#000000,fill:#DC863B;
+  classDef uptodate stroke:#000000,color:#ffffff,fill:#354823;
   classDef none stroke:#000000,color:#000000,fill:#94a4ac;
 ```
+
+### PRISM API
+
+In the process of writing this manuscript, the PRISM API changed ([new
+API
+documentation](https://prism.oregonstate.edu/documents/PRISM_downloads_web_service.pdf)).
+The current `targets` pipeline won’t work with the new API, but we’ve
+provided a function, `get_prism2()` that should be a drop-in replacement
+wherever `get_prism()` is used. Anywhere `read_prism()` is used, the
+`ext` argument will need to be set to `".tif"` as well. E.g. in
+`calc_gdd_doy.R`, `prism_tmin <- read_prism(tmin_dir)` would need to be
+changed to `prism_tmin <- read_prism(tmin_dir, ext = ".tif")`.
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Creates a `get_prism2()` function that should be a drop-in replacement for `get_prism()` should anyone want to re-run this from scratch now that the old PRISM API has been deactivated.  Closes #64